### PR TITLE
change how og url value renders

### DIFF
--- a/_includes/open-graph.html
+++ b/_includes/open-graph.html
@@ -15,5 +15,5 @@
 <meta property="og:type" content="article">
 <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
 {% if page.excerpt %}<meta property="og:description" content="{{ page.excerpt | strip_html }}">{% endif %}
-<meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl }}">
+<meta property="og:url" content="{{ site.url }}{{ page.url }}">
 <meta property="og:site_name" content="{{ site.title }}">

--- a/_includes/open-graph.html
+++ b/_includes/open-graph.html
@@ -15,5 +15,5 @@
 <meta property="og:type" content="article">
 <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
 {% if page.excerpt %}<meta property="og:description" content="{{ page.excerpt | strip_html }}">{% endif %}
-<meta property="og:url" content="{{ site.url }}{{ page.url }}">
+<meta property="og:url" content="{{ site.url }}{{ page.url | replace:'index.html','' }}">
 <meta property="og:site_name" content="{{ site.title }}">


### PR DESCRIPTION
post pages previously would have the following:

```
<meta property="og:url" content="/basket/articles/Missing-Maps-community-mapping/">
```

it should now render as:

```
<meta property="og:url" content="http://osmlab.github.io/basket/articles/Missing-Maps-community-mapping/">
```

this might help with the #16 
